### PR TITLE
adds support for RFC3339 and time parameters #87

### DIFF
--- a/http/jsonapi/runtime/parameters.go
+++ b/http/jsonapi/runtime/parameters.go
@@ -37,7 +37,9 @@ type ScanParameter struct {
 // ScanParameters scans the request using the given path parameter objects
 // in case an error is encountered a 400 along with a jsonapi errors object
 // is sent to the ResponseWriter and false is returned. Returns true if all
-// values were scanned successfully. The used scanning function is fmt.Sscan
+// values were scanned successfully.
+// Parameters can be of type string, time.Time and bool, int8-64, uint8-64,
+// int, float32-64. Note: []byte ist not supported
 func ScanParameters(w http.ResponseWriter, r *http.Request, parameters ...*ScanParameter) bool {
 	for _, param := range parameters {
 		var scanData string

--- a/http/jsonapi/runtime/parameters_test.go
+++ b/http/jsonapi/runtime/parameters_test.go
@@ -256,7 +256,7 @@ func TestScanNumericParametersInQueryFloatArrayFail(t *testing.T) {
 }
 
 func TestScanStringParameters(t *testing.T) {
-	req := httptest.NewRequest("GET", "/foo?value0=12%20asdd&value1=", nil)
+	req := httptest.NewRequest("GET", "/foo?value0=12%20asd+d&value1=", nil)
 	rec := httptest.NewRecorder()
 	var param0 string
 	var param1 string
@@ -270,8 +270,8 @@ func TestScanStringParameters(t *testing.T) {
 	}
 
 	// string
-	if param0 != "12 asdd" {
-		t.Errorf("expected parsing result %#v got: %#v", "12 asdd", param0)
+	if param0 != "12 asd d" {
+		t.Errorf("expected parsing result %#v got: %#v", "12 asd d", param0)
 	}
 	if param1 != "" {
 		t.Errorf("expected parsing result %#v got: %#v", "", param1)


### PR DESCRIPTION
fixes the issue filed in #87 and additionally adds support for the type `time.Time`