### PR TITLE
fix go version to 1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/pace/bricks
 
+go 1.12
+
 require (
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect


### PR DESCRIPTION
Because we now have Go 1.13, but this project uses 1.12, as can be seen here:
https://github.com/pace/bricks/blob/c164a832a18301a94f2faab3f14fc6096bf7d8bd/Dockerfile#L1