### PR TITLE
oauth2: allow creating context with bearer token

### DIFF
--- a/http/oauth2/oauth2.go
+++ b/http/oauth2/oauth2.go
@@ -185,3 +185,10 @@ func tokenFromContext(ctx context.Context) *token {
 
 	return val.(*token)
 }
+
+// WithBearerToken returns a new context that has the given bearer token set.
+// Use BearerToken() to retrieve the token. Use Request() to obtain a request
+// with the Authorization header set accordingly.
+func WithBearerToken(ctx context.Context, bearerToken string) context.Context {
+	return context.WithValue(ctx, tokenKey, &token{value: bearerToken})
+}

--- a/http/oauth2/oauth2_test.go
+++ b/http/oauth2/oauth2_test.go
@@ -210,3 +210,12 @@ func TestUnsucessfulAccessors(t *testing.T) {
 		t.Fatalf("Expected hasScope to return false, got: %v", hasScope)
 	}
 }
+
+func TestWithBearerToken(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithBearerToken(ctx, "some access token")
+	token, ok := BearerToken(ctx)
+	if !ok || token != "some access token" {
+		t.Error("could not store bearer token in context")
+	}
+}


### PR DESCRIPTION
I'm working on a client library which will be used by a web api, and on the cli. In the first case the bearer token will be added to the context by the `oauth2.Middleware`. In the second case I want to add the bearer token to the context manually. This avoids having 2 ways of how a bearer token becomes part of a request.