### PR TITLE
Add error handling based on context alone

### DIFF
--- a/maintenance/errors/error.go
+++ b/maintenance/errors/error.go
@@ -57,6 +57,15 @@ func requestFromContext(ctx context.Context) *http.Request {
 	return nil
 }
 
+// ContextTransfer copies error handling related information from one context to
+// another.
+func ContextTransfer(ctx, targetCtx context.Context) context.Context {
+	if r := requestFromContext(ctx); r != nil {
+		return contextWithRequest(targetCtx, r)
+	}
+	return targetCtx
+}
+
 type contextHandler struct {
 	next http.Handler
 }


### PR DESCRIPTION
Previously in the `maintenance/errors` package we could only handle an error if we had a request and response object. But for some applications the request and response objects aren't generally available to all code that might need error handling. Therefore I restructured the package a bit to generalise logging to sentry and added a `Handle` function that logs an error to the console and to sentry.

For sentry errors it's helpful to have a lot of context. Much of that context is the request. For that reason I added a http handler that adds the request to the context, so that if a request is in the context it can be used to generate a better error context in sentry.