### PR TITLE
jsonapi generator: Always use *time.Time for timestamps

### DIFF
--- a/http/jsonapi/generator/generate_helper.go
+++ b/http/jsonapi/generator/generate_helper.go
@@ -37,7 +37,7 @@ func (g *Generator) goType(stmt *jen.Statement, schema *openapi3.Schema, tags ma
 			} else {
 				addValidator(tags, "rfc3339WithoutZone")
 			}
-			stmt.Qual("time", "Time")
+			stmt.Op("*").Qual("time", "Time") // time.Time can not be nil, so a pointer is needed for omitempty to work
 		case "date":
 			addValidator(tags, "time(2006-01-02)")
 			stmt.Qual("time", "Date")

--- a/http/jsonapi/generator/internal/poi/open-api_test.go
+++ b/http/jsonapi/generator/internal/poi/open-api_test.go
@@ -55,8 +55,8 @@ type CommonOpeningHours []struct {
 // Event ...
 type Event struct {
 	ID        string      `jsonapi:"primary,events,omitempty" valid:"uuid,optional"` // Event ID
-	CreatedAt time.Time   `json:"createdAt,omitempty" jsonapi:"attr,createdAt,omitempty,iso8601" valid:"optional"`
-	EventAt   time.Time   `json:"eventAt,omitempty" jsonapi:"attr,eventAt,omitempty,iso8601" valid:"optional"`
+	CreatedAt *time.Time  `json:"createdAt,omitempty" jsonapi:"attr,createdAt,omitempty,iso8601" valid:"optional"`
+	EventAt   *time.Time  `json:"eventAt,omitempty" jsonapi:"attr,eventAt,omitempty,iso8601" valid:"optional"`
 	Fields    []FieldData `json:"fields,omitempty" jsonapi:"attr,fields,omitempty" valid:"optional"`
 	UserID    string      `json:"userId,omitempty" jsonapi:"attr,userId,omitempty" valid:"optional,uuid"` // Tracks who did last change
 }
@@ -72,9 +72,9 @@ type FieldData struct {
 
 // FieldMetaData ...
 type FieldMetaData struct {
-	SourceID  string    `json:"SourceId,omitempty" jsonapi:"attr,SourceId,omitempty" valid:"optional,uuid"` // Source ID
-	UpdatedAt time.Time `json:"UpdatedAt,omitempty" jsonapi:"attr,UpdatedAt,omitempty,iso8601" valid:"optional"`
-	Field     FieldName `json:"field,omitempty" jsonapi:"attr,field,omitempty" valid:"optional"`
+	SourceID  string     `json:"SourceId,omitempty" jsonapi:"attr,SourceId,omitempty" valid:"optional,uuid"` // Source ID
+	UpdatedAt *time.Time `json:"UpdatedAt,omitempty" jsonapi:"attr,UpdatedAt,omitempty,iso8601" valid:"optional"`
+	Field     FieldName  `json:"field,omitempty" jsonapi:"attr,field,omitempty" valid:"optional"`
 }
 
 // FieldName ...
@@ -156,12 +156,12 @@ type POI struct {
 	Active     bool                 `json:"active,omitempty" jsonapi:"attr,active,omitempty" valid:"optional"`
 	Boundary   CommonGeoJSONPolygon `json:"boundary,omitempty" jsonapi:"attr,boundary,omitempty" valid:"optional"`
 	CountryID  CommonCountryID      `json:"countryId,omitempty" jsonapi:"attr,countryId,omitempty" valid:"optional"`
-	CreatedAt  time.Time            `json:"createdAt,omitempty" jsonapi:"attr,createdAt,omitempty,iso8601" valid:"optional"`
+	CreatedAt  *time.Time           `json:"createdAt,omitempty" jsonapi:"attr,createdAt,omitempty,iso8601" valid:"optional"`
 	Data       []FieldData          `json:"data,omitempty" jsonapi:"attr,data,omitempty" valid:"optional"` // a JSON field containing POI specific data
-	LastSeenAt time.Time            `json:"lastSeenAt,omitempty" jsonapi:"attr,lastSeenAt,omitempty,iso8601" valid:"optional"`
+	LastSeenAt *time.Time           `json:"lastSeenAt,omitempty" jsonapi:"attr,lastSeenAt,omitempty,iso8601" valid:"optional"`
 	Metadata   []FieldMetaData      `json:"metadata,omitempty" jsonapi:"attr,metadata,omitempty" valid:"optional"` // a JSON field containing information about data field origin and update time
 	Position   CommonGeoJSONPoint   `json:"position,omitempty" jsonapi:"attr,position,omitempty" valid:"optional"`
-	UpdatedAt  time.Time            `json:"updatedAt,omitempty" jsonapi:"attr,updatedAt,omitempty,iso8601" valid:"optional"`
+	UpdatedAt  *time.Time           `json:"updatedAt,omitempty" jsonapi:"attr,updatedAt,omitempty,iso8601" valid:"optional"`
 }
 
 // POIType POI type this applies to
@@ -177,7 +177,7 @@ type Policies []*Policy
 type Policy struct {
 	ID        string          `jsonapi:"primary,policies,omitempty" valid:"uuid,optional"` // Policy ID
 	CountryID CommonCountryID `json:"countryId,omitempty" jsonapi:"attr,countryId,omitempty" valid:"optional"`
-	CreatedAt time.Time       `json:"createdAt,omitempty" jsonapi:"attr,createdAt,omitempty,iso8601" valid:"optional"` // Time of POI creation in (iso8601 without zone - expects UTC)
+	CreatedAt *time.Time      `json:"createdAt,omitempty" jsonapi:"attr,createdAt,omitempty,iso8601" valid:"optional"` // Time of POI creation in (iso8601 without zone - expects UTC)
 	PoiType   POIType         `json:"poiType,omitempty" jsonapi:"attr,poiType,omitempty" valid:"optional"`
 	Rules     []PolicyRule    `json:"rules,omitempty" jsonapi:"attr,rules,omitempty" valid:"optional"`
 	UserID    string          `json:"userId,omitempty" jsonapi:"attr,userId,omitempty" valid:"optional,uuid"` // Tracks who did last change
@@ -198,12 +198,12 @@ type PolicyRulePriority struct {
 // Source ...
 type Source struct {
 	ID         string      `jsonapi:"primary,sources,omitempty" valid:"uuid,optional"` // Source ID
-	CreatedAt  time.Time   `json:"createdAt,omitempty" jsonapi:"attr,createdAt,omitempty,iso8601" valid:"optional"`
-	LastDataAt time.Time   `json:"lastDataAt,omitempty" jsonapi:"attr,lastDataAt,omitempty,iso8601" valid:"optional"` // timestamp of last import from source
+	CreatedAt  *time.Time  `json:"createdAt,omitempty" jsonapi:"attr,createdAt,omitempty,iso8601" valid:"optional"`
+	LastDataAt *time.Time  `json:"lastDataAt,omitempty" jsonapi:"attr,lastDataAt,omitempty,iso8601" valid:"optional"` // timestamp of last import from source
 	Name       string      `json:"name,omitempty" jsonapi:"attr,name,omitempty" valid:"optional"`                     // source name, unique
 	PoiType    POIType     `json:"poiType,omitempty" jsonapi:"attr,poiType,omitempty" valid:"optional"`
 	Schema     []FieldName `json:"schema,omitempty" jsonapi:"attr,schema,omitempty" valid:"optional"` // JSON field describing the structure of the updates sent by the data source
-	UpdatedAt  time.Time   `json:"updatedAt,omitempty" jsonapi:"attr,updatedAt,omitempty,iso8601" valid:"optional"`
+	UpdatedAt  *time.Time  `json:"updatedAt,omitempty" jsonapi:"attr,updatedAt,omitempty,iso8601" valid:"optional"`
 }
 
 // Sources ...


### PR DESCRIPTION
As time.Time can not be nil, the "omitempty" tag will never omit this field even if you never set the time.
This change modifies the code generation to always use a pointer, in order to allow the value to be nil.