### PR TITLE
Skip validation for fields of map type

### DIFF
--- a/http/jsonapi/generator/generate_types.go
+++ b/http/jsonapi/generator/generate_types.go
@@ -302,7 +302,13 @@ func (g *Generator) generateStructFields(prefix string, schema *openapi3.Schema,
 		attrSchema := schema.Properties[attrName]
 		tags := make(map[string]string)
 		addJSONAPITags(tags, "attr", attrName)
-		addRequiredOptionalTag(tags, attrName, schema)
+		if attrSchema.Value.AdditionalPropertiesAllowed != nil &&
+			*attrSchema.Value.AdditionalPropertiesAllowed ||
+			attrSchema.Value.AdditionalProperties != nil {
+			addValidator(tags, "-")
+		} else {
+			addRequiredOptionalTag(tags, attrName, schema)
+		}
 
 		// generate attribute field
 		field, err := g.generateAttrField(prefix, attrName, attrSchema, tags)

--- a/http/jsonapi/generator/internal/articles/open-api.json
+++ b/http/jsonapi/generator/internal/articles/open-api.json
@@ -222,6 +222,16 @@
                         "properties": {
                             "something": {
                                 "type": "string"
+                            },
+                            "maptype1": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
+                            "maptype2": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
                             }
                         }
                     }

--- a/http/jsonapi/generator/internal/articles/open-api_test.go
+++ b/http/jsonapi/generator/internal/articles/open-api_test.go
@@ -24,8 +24,10 @@ type Comments []*Comment
 
 // InlineRef ...
 type InlineRef struct {
-	ID        string `jsonapi:"primary,InlineRef,omitempty" valid:"uuid,optional"`
-	Something string `json:"something,omitempty" jsonapi:"attr,something,omitempty" valid:"optional"`
+	ID        string                 `jsonapi:"primary,InlineRef,omitempty" valid:"uuid,optional"`
+	Maptype1  map[string]interface{} `json:"maptype1,omitempty" jsonapi:"attr,maptype1,omitempty" valid:"-"`
+	Maptype2  map[string]string      `json:"maptype2,omitempty" jsonapi:"attr,maptype2,omitempty" valid:"-"`
+	Something string                 `json:"something,omitempty" jsonapi:"attr,something,omitempty" valid:"optional"`
 }
 
 // MapType1 ...
@@ -286,8 +288,10 @@ type UpdateArticleInlineRefContent []*UpdateArticleInlineRefContentItem
 
 // UpdateArticleInlineRefContentItem ...
 type UpdateArticleInlineRefContentItem struct {
-	ID        string `jsonapi:"primary,InlineRef,omitempty" valid:"uuid,optional"`
-	Something string `json:"something,omitempty" jsonapi:"attr,something,omitempty" valid:"optional"`
+	ID        string                 `jsonapi:"primary,InlineRef,omitempty" valid:"uuid,optional"`
+	Maptype1  map[string]interface{} `json:"maptype1,omitempty" jsonapi:"attr,maptype1,omitempty" valid:"-"`
+	Maptype2  map[string]string      `json:"maptype2,omitempty" jsonapi:"attr,maptype2,omitempty" valid:"-"`
+	Something string                 `json:"something,omitempty" jsonapi:"attr,something,omitempty" valid:"optional"`
 }
 
 // UpdateArticleInlineRefRequest ...


### PR DESCRIPTION
Fixes #156 

Checks if the field has `additionalProperties` and adds `validator:"-"` instead of `validator:"optional"` or `validator:"required"`