### PR TITLE
Ignore errors caused by context cancellation

### DIFF
--- a/http/jsonapi/generator/internal/articles/open-api_test.go
+++ b/http/jsonapi/generator/internal/articles/open-api_test.go
@@ -92,7 +92,13 @@ func UpdateArticleCommentsHandler(service Service) http.Handler {
 			// Invoke service that implements the business logic
 			err := service.UpdateArticleComments(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "UpdateArticleCommentsHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "UpdateArticleCommentsHandler", w, r)
+				}
 			}
 		}
 	})
@@ -137,7 +143,13 @@ func UpdateArticleInlineTypeHandler(service Service) http.Handler {
 			// Invoke service that implements the business logic
 			err := service.UpdateArticleInlineType(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "UpdateArticleInlineTypeHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "UpdateArticleInlineTypeHandler", w, r)
+				}
 			}
 		}
 	})
@@ -182,7 +194,13 @@ func UpdateArticleInlineRefHandler(service Service) http.Handler {
 			// Invoke service that implements the business logic
 			err := service.UpdateArticleInlineRef(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "UpdateArticleInlineRefHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "UpdateArticleInlineRefHandler", w, r)
+				}
 			}
 		}
 	})

--- a/http/jsonapi/generator/internal/fueling/open-api_test.go
+++ b/http/jsonapi/generator/internal/fueling/open-api_test.go
@@ -160,7 +160,13 @@ func ProcessPaymentHandler(service Service) http.Handler {
 			// Invoke service that implements the business logic
 			err := service.ProcessPayment(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "ProcessPaymentHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "ProcessPaymentHandler", w, r)
+				}
 			}
 		}
 	})
@@ -209,7 +215,13 @@ func ApproachingAtTheForecourtHandler(service Service) http.Handler {
 			// Invoke service that implements the business logic
 			err := service.ApproachingAtTheForecourt(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "ApproachingAtTheForecourtHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "ApproachingAtTheForecourtHandler", w, r)
+				}
 			}
 		}
 	})
@@ -257,7 +269,13 @@ func GetPumpHandler(service Service) http.Handler {
 		// Invoke service that implements the business logic
 		err := service.GetPump(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetPumpHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetPumpHandler", w, r)
+			}
 		}
 	})
 }
@@ -316,7 +334,13 @@ func WaitOnPumpStatusChangeHandler(service Service) http.Handler {
 		// Invoke service that implements the business logic
 		err := service.WaitOnPumpStatusChange(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "WaitOnPumpStatusChangeHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "WaitOnPumpStatusChangeHandler", w, r)
+			}
 		}
 	})
 }

--- a/http/jsonapi/generator/internal/pay/open-api_test.go
+++ b/http/jsonapi/generator/internal/pay/open-api_test.go
@@ -125,7 +125,13 @@ func GetPaymentMethodsHandler(service Service, authBackend AuthorizationBackend)
 		// Invoke service that implements the business logic
 		err := service.GetPaymentMethods(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetPaymentMethodsHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetPaymentMethodsHandler", w, r)
+			}
 		}
 	})
 }
@@ -180,7 +186,13 @@ func CreatePaymentMethodSEPAHandler(service Service, authBackend AuthorizationBa
 			// Invoke service that implements the business logic
 			err := service.CreatePaymentMethodSEPA(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "CreatePaymentMethodSEPAHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "CreatePaymentMethodSEPAHandler", w, r)
+				}
 			}
 		}
 	})
@@ -229,7 +241,13 @@ func DeletePaymentMethodHandler(service Service, authBackend AuthorizationBacken
 		// Invoke service that implements the business logic
 		err := service.DeletePaymentMethod(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "DeletePaymentMethodHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "DeletePaymentMethodHandler", w, r)
+			}
 		}
 	})
 }
@@ -273,7 +291,13 @@ func AuthorizePaymentMethodHandler(service Service, authBackend AuthorizationBac
 			// Invoke service that implements the business logic
 			err := service.AuthorizePaymentMethod(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "AuthorizePaymentMethodHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "AuthorizePaymentMethodHandler", w, r)
+				}
 			}
 		}
 	})
@@ -321,7 +345,13 @@ func DeletePaymentTokenHandler(service Service, authBackend AuthorizationBackend
 		// Invoke service that implements the business logic
 		err := service.DeletePaymentToken(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "DeletePaymentTokenHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "DeletePaymentTokenHandler", w, r)
+			}
 		}
 	})
 }
@@ -361,7 +391,13 @@ func GetPaymentMethodsIncludingCreditCheckHandler(service Service, authBackend A
 		// Invoke service that implements the business logic
 		err := service.GetPaymentMethodsIncludingCreditCheck(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetPaymentMethodsIncludingCreditCheckHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetPaymentMethodsIncludingCreditCheckHandler", w, r)
+			}
 		}
 	})
 }
@@ -401,7 +437,13 @@ func GetPaymentMethodsIncludingPaymentTokenHandler(service Service, authBackend 
 		// Invoke service that implements the business logic
 		err := service.GetPaymentMethodsIncludingPaymentToken(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetPaymentMethodsIncludingPaymentTokenHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetPaymentMethodsIncludingPaymentTokenHandler", w, r)
+			}
 		}
 	})
 }
@@ -449,7 +491,13 @@ func ProcessPaymentHandler(service Service, authBackend AuthorizationBackend) ht
 			// Invoke service that implements the business logic
 			err := service.ProcessPayment(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "ProcessPaymentHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "ProcessPaymentHandler", w, r)
+				}
 			}
 		}
 	})

--- a/http/jsonapi/generator/internal/poi/open-api_test.go
+++ b/http/jsonapi/generator/internal/poi/open-api_test.go
@@ -328,7 +328,13 @@ func GetAppsHandler(service Service, authBackend AuthorizationBackend) http.Hand
 		// Invoke service that implements the business logic
 		err := service.GetApps(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetAppsHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetAppsHandler", w, r)
+			}
 		}
 	})
 }
@@ -369,7 +375,13 @@ func CreateAppHandler(service Service, authBackend AuthorizationBackend) http.Ha
 			// Invoke service that implements the business logic
 			err := service.CreateApp(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "CreateAppHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "CreateAppHandler", w, r)
+				}
 			}
 		}
 	})
@@ -444,7 +456,13 @@ func CheckForPaceAppHandler(service Service, authBackend AuthorizationBackend) h
 		// Invoke service that implements the business logic
 		err := service.CheckForPaceApp(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "CheckForPaceAppHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "CheckForPaceAppHandler", w, r)
+			}
 		}
 	})
 }
@@ -492,7 +510,13 @@ func DeleteAppHandler(service Service, authBackend AuthorizationBackend) http.Ha
 		// Invoke service that implements the business logic
 		err := service.DeleteApp(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "DeleteAppHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "DeleteAppHandler", w, r)
+			}
 		}
 	})
 }
@@ -540,7 +564,13 @@ func GetAppHandler(service Service, authBackend AuthorizationBackend) http.Handl
 		// Invoke service that implements the business logic
 		err := service.GetApp(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetAppHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetAppHandler", w, r)
+			}
 		}
 	})
 }
@@ -590,7 +620,13 @@ func UpdateAppHandler(service Service, authBackend AuthorizationBackend) http.Ha
 			// Invoke service that implements the business logic
 			err := service.UpdateApp(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "UpdateAppHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "UpdateAppHandler", w, r)
+				}
 			}
 		}
 	})
@@ -639,7 +675,13 @@ func GetAppPOIsRelationshipsHandler(service Service, authBackend AuthorizationBa
 		// Invoke service that implements the business logic
 		err := service.GetAppPOIsRelationships(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetAppPOIsRelationshipsHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetAppPOIsRelationshipsHandler", w, r)
+			}
 		}
 	})
 }
@@ -689,7 +731,13 @@ func UpdateAppPOIsRelationshipsHandler(service Service, authBackend Authorizatio
 			// Invoke service that implements the business logic
 			err := service.UpdateAppPOIsRelationships(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "UpdateAppPOIsRelationshipsHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "UpdateAppPOIsRelationshipsHandler", w, r)
+				}
 			}
 		}
 	})
@@ -748,7 +796,13 @@ func GetEventsHandler(service Service, authBackend AuthorizationBackend) http.Ha
 		// Invoke service that implements the business logic
 		err := service.GetEvents(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetEventsHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetEventsHandler", w, r)
+			}
 		}
 	})
 }
@@ -842,7 +896,13 @@ func GetGasStationsHandler(service Service, authBackend AuthorizationBackend) ht
 		// Invoke service that implements the business logic
 		err := service.GetGasStations(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetGasStationsHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetGasStationsHandler", w, r)
+			}
 		}
 	})
 }
@@ -890,7 +950,13 @@ func GetGasStationHandler(service Service, authBackend AuthorizationBackend) htt
 		// Invoke service that implements the business logic
 		err := service.GetGasStation(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetGasStationHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetGasStationHandler", w, r)
+			}
 		}
 	})
 }
@@ -952,7 +1018,13 @@ func GetPoisHandler(service Service, authBackend AuthorizationBackend) http.Hand
 		// Invoke service that implements the business logic
 		err := service.GetPois(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetPoisHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetPoisHandler", w, r)
+			}
 		}
 	})
 }
@@ -1000,7 +1072,13 @@ func GetPoiHandler(service Service, authBackend AuthorizationBackend) http.Handl
 		// Invoke service that implements the business logic
 		err := service.GetPoi(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetPoiHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetPoiHandler", w, r)
+			}
 		}
 	})
 }
@@ -1050,7 +1128,13 @@ func ChangePoiHandler(service Service, authBackend AuthorizationBackend) http.Ha
 			// Invoke service that implements the business logic
 			err := service.ChangePoi(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "ChangePoiHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "ChangePoiHandler", w, r)
+				}
 			}
 		}
 	})
@@ -1113,7 +1197,13 @@ func GetPoliciesHandler(service Service, authBackend AuthorizationBackend) http.
 		// Invoke service that implements the business logic
 		err := service.GetPolicies(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetPoliciesHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetPoliciesHandler", w, r)
+			}
 		}
 	})
 }
@@ -1154,7 +1244,13 @@ func CreatePolicyHandler(service Service, authBackend AuthorizationBackend) http
 			// Invoke service that implements the business logic
 			err := service.CreatePolicy(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "CreatePolicyHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "CreatePolicyHandler", w, r)
+				}
 			}
 		}
 	})
@@ -1203,7 +1299,13 @@ func GetPolicyHandler(service Service, authBackend AuthorizationBackend) http.Ha
 		// Invoke service that implements the business logic
 		err := service.GetPolicy(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetPolicyHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetPolicyHandler", w, r)
+			}
 		}
 	})
 }
@@ -1261,7 +1363,13 @@ func GetSourcesHandler(service Service, authBackend AuthorizationBackend) http.H
 		// Invoke service that implements the business logic
 		err := service.GetSources(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetSourcesHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetSourcesHandler", w, r)
+			}
 		}
 	})
 }
@@ -1302,7 +1410,13 @@ func CreateSourceHandler(service Service, authBackend AuthorizationBackend) http
 			// Invoke service that implements the business logic
 			err := service.CreateSource(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "CreateSourceHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "CreateSourceHandler", w, r)
+				}
 			}
 		}
 	})
@@ -1351,7 +1465,13 @@ func DeleteSourceHandler(service Service, authBackend AuthorizationBackend) http
 		// Invoke service that implements the business logic
 		err := service.DeleteSource(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "DeleteSourceHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "DeleteSourceHandler", w, r)
+			}
 		}
 	})
 }
@@ -1399,7 +1519,13 @@ func GetSourceHandler(service Service, authBackend AuthorizationBackend) http.Ha
 		// Invoke service that implements the business logic
 		err := service.GetSource(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetSourceHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetSourceHandler", w, r)
+			}
 		}
 	})
 }
@@ -1449,7 +1575,13 @@ func UpdateSourceHandler(service Service, authBackend AuthorizationBackend) http
 			// Invoke service that implements the business logic
 			err := service.UpdateSource(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "UpdateSourceHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "UpdateSourceHandler", w, r)
+				}
 			}
 		}
 	})
@@ -1491,7 +1623,13 @@ func CreateSubscriptionHandler(service Service, authBackend AuthorizationBackend
 			// Invoke service that implements the business logic
 			err := service.CreateSubscription(ctx, &writer, &request)
 			if err != nil {
-				errors.HandleError(err, "CreateSubscriptionHandler", w, r)
+				select {
+				case <-ctx.Done():
+					// Context cancellation should not be reported if it's the request context
+					errors.HandleErrorNoStack(ctx, err)
+				default:
+					errors.HandleError(err, "CreateSubscriptionHandler", w, r)
+				}
 			}
 		}
 	})
@@ -1528,7 +1666,13 @@ func GetTilesHandler(service Service, authBackend AuthorizationBackend) http.Han
 		// Invoke service that implements the business logic
 		err := service.GetTiles(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetTilesHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetTilesHandler", w, r)
+			}
 		}
 	})
 }

--- a/http/jsonapi/generator/internal/securitytest/open-api_test.go
+++ b/http/jsonapi/generator/internal/securitytest/open-api_test.go
@@ -80,7 +80,13 @@ func GetTestHandler(service Service, authBackend AuthorizationBackend) http.Hand
 		// Invoke service that implements the business logic
 		err := service.GetTest(ctx, &writer, &request)
 		if err != nil {
-			errors.HandleError(err, "GetTestHandler", w, r)
+			select {
+			case <-ctx.Done():
+				// Context cancellation should not be reported if it's the request context
+				errors.HandleErrorNoStack(ctx, err)
+			default:
+				errors.HandleError(err, "GetTestHandler", w, r)
+			}
 		}
 	})
 }

--- a/http/jsonapi/runtime/error.go
+++ b/http/jsonapi/runtime/error.go
@@ -118,7 +118,7 @@ func WriteError(w http.ResponseWriter, code int, err error) {
 		if source := ei.Source; source != nil {
 			ev = ev.Fields(*source)
 		}
-		ev.Err(ei).Msg(ei.Detail)
+		ev.Err(ei).Msgf("Error sent to the client. Details: %v", ei.Detail)
 	}
 }
 

--- a/maintenance/errors/error.go
+++ b/maintenance/errors/error.go
@@ -108,7 +108,7 @@ func HandleError(rp interface{}, handlerName string, w http.ResponseWriter, r *h
 
 	sentryEvent{ctx, r, rp, handlerName}.Send()
 
-	runtime.WriteError(w, http.StatusInternalServerError, errors.New("Error"))
+	runtime.WriteError(w, http.StatusInternalServerError, errors.New("Internal Server Error"))
 }
 
 // Handle logs the given error and reports it to sentry.
@@ -133,6 +133,10 @@ func HandleWithCtx(ctx context.Context, handlerName string) {
 
 		sentryEvent{ctx, nil, rp, handlerName}.Send()
 	}
+}
+
+func HandleErrorNoStack(ctx context.Context, err error) {
+	log.Ctx(ctx).Info().Msgf("Received error, will not handle further: %v", err)
 }
 
 // New returns an error that formats as the given text.


### PR DESCRIPTION
This was done to prevent long stack traces in cases of http requests being cancelled