### PR TITLE
skip reporting line in sentry error messages

### DIFF
--- a/maintenance/errors/error.go
+++ b/maintenance/errors/error.go
@@ -219,8 +219,5 @@ func (e sentryEvent) build() *raven.Packet {
 	// from env
 	packet.Extra["microservice"] = os.Getenv("JAEGER_SERVICE_NAME")
 
-	b, _ := packet.JSON()
-	log.Print(string(b))
-
 	return packet
 }

--- a/maintenance/errors/error_test.go
+++ b/maintenance/errors/error_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 )
 
 // Note: Tests that there is no panic if there are no
@@ -53,4 +54,21 @@ func TestWrapWithExtra(t *testing.T) {
 	if WrapWithExtra(New("Test"), map[string]interface{}{}).Error() != "Test" {
 		t.Error("invalid implementation of errors.WrapWithExtra")
 	}
+}
+
+func TestStackTrace(t *testing.T) {
+	e := sentryEvent{
+		ctx:         context.Background(),
+		handlerName: "TestStackTrace",
+		r:           nil,
+		level:       1,
+		req:         nil,
+	}
+	pak := e.build()
+
+	d, err := pak.JSON()
+	assert.NoError(t, err)
+
+	assert.NotContains(t, string(d), `"module":"testing"`)
+	assert.NotContains(t, string(d), `"filename":"testing/testing.go"`)
 }


### PR DESCRIPTION
Sentry uses the first line of the stack trace
to createe the error and issue report, the line
is currently filled with the reporter, e.g.:

*errors.errorStringgithub.com/pace/bricks/maintenance/errors in HandleError

The above line is not helpful, depending on the
context the next line or the line after that contain
the origin of the panic (or error message).