### PR TITLE
Fix log.Sink and add NoopSink

### DIFF
--- a/maintenance/log/handler.go
+++ b/maintenance/log/handler.go
@@ -17,12 +17,11 @@ import (
 // Handler returns a middleware that handles all of the logging aspects of
 // any incoming http request
 func Handler() func(http.Handler) http.Handler {
-	sink := &Sink{}
 	return func(next http.Handler) http.Handler {
-		return hlog.NewHandler(log.Logger.Output(sink))(
+		return hlog.NewHandler(log.Logger)(
 			hlog.AccessHandler(requestCompleted)(
 				hlog.RequestIDHandler("req_id", "Request-Id")(
-					handlerWithSink(sink)(next))))
+					handlerWithSink()(next))))
 	}
 }
 

--- a/maintenance/log/sink_test.go
+++ b/maintenance/log/sink_test.go
@@ -37,5 +37,5 @@ func Test_Sink(t *testing.T) {
 	var result []interface{}
 	require.NoError(t, json.Unmarshal(logs, &result), "could not unmarshal logs")
 
-	require.Len(t, result, 2, "expecting exactly two logs, but got: %v", logs)
+	require.Len(t, result, 1, "expecting exactly one log, but got %d", len(result))
 }


### PR DESCRIPTION
In the first version of the `log.Sink` implementation, a single `log.Sink` instance was registered on all incoming requests which leads to an effect that every sentry message contained all log messages. This pr fixes this behaviour and also introduces a `log.NoopSink` to be able to store logs in this sink while discarding them before reaching the logger.