### PR TITLE
Routine retry on panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gorilla/mux v1.6.2
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect
+	github.com/jpillora/backoff v1.0.0
 	github.com/mattn/go-isatty v0.0.8
 	github.com/mattn/goveralls v0.0.5
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a h1:eeaG9XMUvRBYXJi4pg1ZKM7nxc5AfXfojeLLW7O5J3k=
 github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/routine/backoff.go
+++ b/pkg/routine/backoff.go
@@ -1,0 +1,33 @@
+// Copyright © 2020 by PACE Telematics GmbH. All rights reserved.
+// Created at 2020/03/09 by Marius Neugebauer
+
+package routine
+
+import (
+	"time"
+
+	exponential "github.com/jpillora/backoff"
+)
+
+// Manages several backoffs of which at any time only one or none is used. When
+// getting the duration of one backoff, all others are reset.
+type combinedExponentialBackoff map[interface{}]*exponential.Backoff
+
+// ResetAll resets all backoffs.
+func (all combinedExponentialBackoff) ResetAll() {
+	for _, backoff := range all {
+		backoff.Reset()
+	}
+}
+
+// Duration returns the duration of the requested backoff and resets all others.
+func (all combinedExponentialBackoff) Duration(key interface{}) (dur time.Duration) {
+	for k, backoff := range all {
+		if k == key {
+			dur = backoff.Duration()
+		} else {
+			backoff.Reset()
+		}
+	}
+	return
+}

--- a/pkg/routine/redis_lock.go
+++ b/pkg/routine/redis_lock.go
@@ -5,12 +5,15 @@ package routine
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/bsm/redislock"
 	"github.com/go-redis/redis"
 	redisbackend "github.com/pace/bricks/backend/redis"
+	"github.com/pace/bricks/maintenance/errors"
+	"github.com/pace/bricks/maintenance/log"
 )
 
 func routineThatKeepsRunningOneInstance(name string, routine func(context.Context)) func(context.Context) {
@@ -23,8 +26,10 @@ func routineThatKeepsRunningOneInstance(name string, routine func(context.Contex
 				return
 			case <-time.After(tryAgainIn):
 			}
-			lockCtx := obtainLock(ctx, locker, "routine:lock:"+name, cfg.RedisLockTTL)
-			if lockCtx != nil {
+			lockCtx, err := obtainLock(ctx, locker, "routine:lock:"+name, cfg.RedisLockTTL)
+			if err != nil {
+				go errors.Handle(ctx, err) // report error to Sentry, non-blocking
+			} else if lockCtx != nil {
 				routine(lockCtx)
 			}
 			tryAgainIn = cfg.RedisLockTTL / 5
@@ -44,34 +49,38 @@ func getDefaultRedisClient() *redis.Client {
 
 // Try to obtain a lock. Return a sub-context of ctx that is canceled once the
 // lock is lost or ctx is done.
-func obtainLock(ctx context.Context, locker *redislock.Client, key string, ttl time.Duration) context.Context {
+func obtainLock(ctx context.Context, locker *redislock.Client, key string, ttl time.Duration) (context.Context, error) {
+	num := ctx.Value(ctxNumKey{}).(int64)
+
 	// obtain lock
 	lock, err := locker.Obtain(key, ttl, nil)
 	if err == redislock.ErrNotObtained {
-		return nil
+		return nil, nil
 	} else if err != nil {
-		panic(err)
+		log.Ctx(ctx).Debug().Err(err).Msg("could not obtain lock")
+		return nil, err
 	}
 
 	// keep up lock, cancel lockCtx otherwise
 	lockCtx, cancel := context.WithCancel(ctx)
 	go func() {
+		defer errors.HandleWithCtx(ctx, fmt.Sprintf("routine %d: keep up lock", num)) // handle panics
 		keepUpLock(ctx, lock, ttl)
 		cancel()
 		err := lock.Release()
 		if err != nil && err != redislock.ErrLockNotHeld {
-			panic(err)
+			log.Ctx(ctx).Debug().Err(err).Msg("could not release lock")
 		}
 	}()
 
-	return lockCtx
+	return lockCtx, nil
 }
 
 // Try to keep up a lock for as long as the context is valid. Return once the
 // lock is lost or the context is done.
 func keepUpLock(ctx context.Context, lock *redislock.Lock, refreshTTL time.Duration) {
 	refreshInterval := refreshTTL / 5
-	lockRunsOutIn := refreshTTL // initial value must be > refresh interval
+	lockRunsOutIn := refreshTTL // initial value after obtaining the lock
 	for {
 		select {
 		case <-ctx.Done():
@@ -89,11 +98,13 @@ func keepUpLock(ctx context.Context, lock *redislock.Lock, refreshTTL time.Durat
 			// Don't return just yet. Get the TTL of the lock and try to
 			// refresh for as long as the TTL is not over.
 			if lockRunsOutIn, err = lock.TTL(); err != nil {
-				panic(err)
+				log.Ctx(ctx).Debug().Err(err).Msg("could not get ttl of lock")
+				return // assuming we lost the lock
 			}
 			continue
 		} else if err != nil {
-			panic(err)
+			log.Ctx(ctx).Debug().Err(err).Msg("could not refresh lock")
+			return // assuming we lost the lock
 		}
 		// reset, because the lock was refreshed
 		lockRunsOutIn = refreshTTL

--- a/pkg/routine/routine.go
+++ b/pkg/routine/routine.go
@@ -89,8 +89,9 @@ func Run(parentCtx context.Context, routine func(context.Context)) (cancel conte
 	ctx := log.Ctx(parentCtx).WithContext(context.Background())
 	ctx = oauth2.ContextTransfer(parentCtx, ctx)
 	ctx = errors.ContextTransfer(parentCtx, ctx)
-	// add routine number to logger
+	// add routine number to context and logger
 	num := atomic.AddInt64(&ctr, 1)
+	ctx = context.WithValue(ctx, ctxNumKey{}, num)
 	logger := log.Ctx(ctx).With().Int64("routine", num).Logger()
 	ctx = logger.WithContext(ctx)
 	// get cancel function
@@ -115,6 +116,8 @@ func Run(parentCtx context.Context, routine func(context.Context)) (cancel conte
 	}()
 	return
 }
+
+type ctxNumKey struct{}
 
 var (
 	contextsMx sync.Mutex

--- a/pkg/routine/routine.go
+++ b/pkg/routine/routine.go
@@ -73,7 +73,10 @@ func RunNamed(parentCtx context.Context, name string, routine func(context.Conte
 	}
 
 	if o.keepRunningOneInstance {
-		routine = routineThatKeepsRunningOneInstance(name, routine)
+		routine = (&routineThatKeepsRunningOneInstance{
+			Name:    name,
+			Routine: routine,
+		}).Run
 	}
 
 	return Run(parentCtx, routine)

--- a/pkg/routine/routine.go
+++ b/pkg/routine/routine.go
@@ -111,8 +111,8 @@ func Run(parentCtx context.Context, routine func(context.Context)) (cancel conte
 	}()
 	go func() {
 		defer errors.HandleWithCtx(ctx, fmt.Sprintf("routine %d", num)) // handle panics
+		defer cancel()
 		routine(ctx)
-		cancel()
 	}()
 	return
 }

--- a/vendor/github.com/jpillora/backoff/LICENSE
+++ b/vendor/github.com/jpillora/backoff/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Jaime Pillora
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jpillora/backoff/README.md
+++ b/vendor/github.com/jpillora/backoff/README.md
@@ -1,0 +1,119 @@
+# Backoff
+
+A simple exponential backoff counter in Go (Golang)
+
+[![GoDoc](https://godoc.org/github.com/jpillora/backoff?status.svg)](https://godoc.org/github.com/jpillora/backoff) [![Circle CI](https://circleci.com/gh/jpillora/backoff.svg?style=shield)](https://circleci.com/gh/jpillora/backoff)
+
+### Install
+
+```
+$ go get -v github.com/jpillora/backoff
+```
+
+### Usage
+
+Backoff is a `time.Duration` counter. It starts at `Min`. After every call to `Duration()` it is  multiplied by `Factor`. It is capped at `Max`. It returns to `Min` on every call to `Reset()`. `Jitter` adds randomness ([see below](#example-using-jitter)). Used in conjunction with the `time` package.
+
+---
+
+#### Simple example
+
+``` go
+
+b := &backoff.Backoff{
+	//These are the defaults
+	Min:    100 * time.Millisecond,
+	Max:    10 * time.Second,
+	Factor: 2,
+	Jitter: false,
+}
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+
+fmt.Printf("Reset!\n")
+b.Reset()
+
+fmt.Printf("%s\n", b.Duration())
+```
+
+```
+100ms
+200ms
+400ms
+Reset!
+100ms
+```
+
+---
+
+#### Example using `net` package
+
+``` go
+b := &backoff.Backoff{
+    Max:    5 * time.Minute,
+}
+
+for {
+	conn, err := net.Dial("tcp", "example.com:5309")
+	if err != nil {
+		d := b.Duration()
+		fmt.Printf("%s, reconnecting in %s", err, d)
+		time.Sleep(d)
+		continue
+	}
+	//connected
+	b.Reset()
+	conn.Write([]byte("hello world!"))
+	// ... Read ... Write ... etc
+	conn.Close()
+	//disconnected
+}
+
+```
+
+---
+
+#### Example using `Jitter`
+
+Enabling `Jitter` adds some randomization to the backoff durations. [See Amazon's writeup of performance gains using jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html). Seeding is not necessary but doing so gives repeatable results.
+
+```go
+import "math/rand"
+
+b := &backoff.Backoff{
+	Jitter: true,
+}
+
+rand.Seed(42)
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+
+fmt.Printf("Reset!\n")
+b.Reset()
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+```
+
+```
+100ms
+106.600049ms
+281.228155ms
+Reset!
+100ms
+104.381845ms
+214.957989ms
+```
+
+#### Documentation
+
+https://godoc.org/github.com/jpillora/backoff
+
+#### Credits
+
+Forked from [some JavaScript](https://github.com/segmentio/backo) written by [@tj](https://github.com/tj)

--- a/vendor/github.com/jpillora/backoff/backoff.go
+++ b/vendor/github.com/jpillora/backoff/backoff.go
@@ -1,0 +1,100 @@
+// Package backoff provides an exponential-backoff implementation.
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"sync/atomic"
+	"time"
+)
+
+// Backoff is a time.Duration counter, starting at Min. After every call to
+// the Duration method the current timing is multiplied by Factor, but it
+// never exceeds Max.
+//
+// Backoff is not generally concurrent-safe, but the ForAttempt method can
+// be used concurrently.
+type Backoff struct {
+	attempt uint64
+	// Factor is the multiplying factor for each increment step
+	Factor float64
+	// Jitter eases contention by randomizing backoff steps
+	Jitter bool
+	// Min and Max are the minimum and maximum values of the counter
+	Min, Max time.Duration
+}
+
+// Duration returns the duration for the current attempt before incrementing
+// the attempt counter. See ForAttempt.
+func (b *Backoff) Duration() time.Duration {
+	d := b.ForAttempt(float64(atomic.AddUint64(&b.attempt, 1) - 1))
+	return d
+}
+
+const maxInt64 = float64(math.MaxInt64 - 512)
+
+// ForAttempt returns the duration for a specific attempt. This is useful if
+// you have a large number of independent Backoffs, but don't want use
+// unnecessary memory storing the Backoff parameters per Backoff. The first
+// attempt should be 0.
+//
+// ForAttempt is concurrent-safe.
+func (b *Backoff) ForAttempt(attempt float64) time.Duration {
+	// Zero-values are nonsensical, so we use
+	// them to apply defaults
+	min := b.Min
+	if min <= 0 {
+		min = 100 * time.Millisecond
+	}
+	max := b.Max
+	if max <= 0 {
+		max = 10 * time.Second
+	}
+	if min >= max {
+		// short-circuit
+		return max
+	}
+	factor := b.Factor
+	if factor <= 0 {
+		factor = 2
+	}
+	//calculate this duration
+	minf := float64(min)
+	durf := minf * math.Pow(factor, attempt)
+	if b.Jitter {
+		durf = rand.Float64()*(durf-minf) + minf
+	}
+	//ensure float64 wont overflow int64
+	if durf > maxInt64 {
+		return max
+	}
+	dur := time.Duration(durf)
+	//keep within bounds
+	if dur < min {
+		return min
+	}
+	if dur > max {
+		return max
+	}
+	return dur
+}
+
+// Reset restarts the current attempt counter at zero.
+func (b *Backoff) Reset() {
+	atomic.StoreUint64(&b.attempt, 0)
+}
+
+// Attempt returns the current attempt counter value.
+func (b *Backoff) Attempt() float64 {
+	return float64(atomic.LoadUint64(&b.attempt))
+}
+
+// Copy returns a backoff with equals constraints as the original
+func (b *Backoff) Copy() *Backoff {
+	return &Backoff{
+		Factor: b.Factor,
+		Jitter: b.Jitter,
+		Min:    b.Min,
+		Max:    b.Max,
+	}
+}

--- a/vendor/github.com/jpillora/backoff/go.mod
+++ b/vendor/github.com/jpillora/backoff/go.mod
@@ -1,0 +1,3 @@
+module github.com/jpillora/backoff
+
+go 1.13

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,6 +62,9 @@ github.com/inconshreveable/mousetrap
 # github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a
 ## explicit
 github.com/jinzhu/inflection
+# github.com/jpillora/backoff v1.0.0
+## explicit
+github.com/jpillora/backoff
 # github.com/mattn/go-isatty v0.0.8
 ## explicit
 github.com/mattn/go-isatty


### PR DESCRIPTION
All changes regarding the `KeepRunningOneInstance` option:

* Use exponential backoff when obtaining/refreshing the lock fails unexpectedly.
* Use exponential backoff when the routine panics.
* Report panics in all cases to Sentry.
* Report to Sentry if a lock could not be obtained unexpectedly.
* Make sure contexts are canceled on errors/panics or if the routine returns.
* Fix that a lock is refreshed after the routine already returned.
* Fix that routine is not restarted because the obtaining the lock panicked.