### PR TITLE
HTTP transport: Return specific errors in some cases:

### DIFF
--- a/http/transport/circuit_breaker_tripper_test.go
+++ b/http/transport/circuit_breaker_tripper_test.go
@@ -20,13 +20,13 @@ func TestCircuitBreakerTripper(t *testing.T) {
 		chain := Chain(breaker).Final(&failingRoundTripper{})
 
 		for i := 0; i < 6; i++ {
-			if _, err := chain.RoundTrip(req); errors.Is(err, gobreaker.ErrOpenState) {
-				t.Errorf("got err=%q, before expected", gobreaker.ErrOpenState)
+			if _, err := chain.RoundTrip(req); errors.Is(err, ErrCircuitBroken) {
+				t.Errorf("got err=%q, before expected", ErrCircuitBroken)
 			}
 		}
 
-		if _, err := chain.RoundTrip(req); !errors.Is(err, gobreaker.ErrOpenState) {
-			t.Errorf("wanted err=%q, got err=%q", gobreaker.ErrOpenState, err)
+		if _, err := chain.RoundTrip(req); !errors.Is(err, ErrCircuitBroken) {
+			t.Errorf("wanted err=%q, got err=%q", ErrCircuitBroken, err)
 		}
 	})
 

--- a/http/transport/errors.go
+++ b/http/transport/errors.go
@@ -1,0 +1,8 @@
+package transport
+
+import "errors"
+
+var (
+	ErrRetryFailed   = errors.New("failed after maximum number of retries")
+	ErrCircuitBroken = errors.New("circuit to remote host is open")
+)

--- a/maintenance/errors/error_test.go
+++ b/maintenance/errors/error_test.go
@@ -246,7 +246,7 @@ func TestHandlerWithLogSink(t *testing.T) {
 	var sink1LogLines []json.RawMessage
 	assert.NoError(t, json.Unmarshal(sink1.ToJSON(), &sink1LogLines), "failed extracting logs from sink1")
 
-	assert.Len(t, sink1LogLines, 1, "more log lines than expected")
+	assert.Len(t, sink1LogLines, 2, "more log lines than expected")
 	assert.Contains(t, string(sink1LogLines[0]), "ONLY FOR SINK1", "missing log line")
 
 	sink2, ok := log.SinkFromContext(sink2Ctx)

--- a/maintenance/log/sink_test.go
+++ b/maintenance/log/sink_test.go
@@ -37,5 +37,5 @@ func Test_Sink(t *testing.T) {
 	var result []interface{}
 	require.NoError(t, json.Unmarshal(logs, &result), "could not unmarshal logs")
 
-	require.Len(t, result, 1, "expecting exactly one log, but got %d", len(result))
+	require.Len(t, result, 2, "expecting exactly one log, but got %d", len(result))
 }


### PR DESCRIPTION
* when the retry limit is exceeded
* when the circuit is open (i.e. host is unreachable)