### PR TITLE
log every request on retry

### DIFF
--- a/http/transport/default_transport.go
+++ b/http/transport/default_transport.go
@@ -7,9 +7,9 @@ package transport
 // If not explicitly finalized via `Final` it uses `http.DefaultTransport` as finalizer.
 func NewDefaultTransportChain() *RoundTripperChain {
 	return Chain(
-		NewDumpRoundTripperEnv(),
 		NewDefaultRetryRoundTripper(),
 		&JaegerRoundTripper{},
+		NewDumpRoundTripperEnv(),
 		&LoggingRoundTripper{},
 		&LocaleRoundTripper{},
 		&RequestIDRoundTripper{},

--- a/http/transport/default_transport_test.go
+++ b/http/transport/default_transport_test.go
@@ -5,27 +5,47 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+
+	"github.com/pace/bricks/maintenance/log"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewDefaultTransportChain(t *testing.T) {
+	old := os.Getenv("HTTP_TRANSPORT_DUMP")
+	defer os.Setenv("HTTP_TRANSPORT_DUMP", old)
+	os.Setenv("HTTP_TRANSPORT_DUMP", "request,response,body")
+
 	t.Run("Finalizer not set explicitly", func(t *testing.T) {
 		b := "Hello World"
 		tr := NewDefaultTransportChain()
+		retry := 0
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			retry++
+			if retry == 5 {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, b)
+				return
+			}
+			w.WriteHeader(http.StatusBadGateway)
 			fmt.Fprint(w, b)
 		}))
-		defer ts.Close()
 
 		req := httptest.NewRequest("GET", ts.URL, nil)
+		req = req.WithContext(log.WithContext(context.Background()))
 		resp, err := tr.RoundTrip(req)
 		if err != nil {
 			t.Fatal(err)
 		}
+		ts.Close()
+
+		assert.Equal(t, retry, 5)
 
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -42,6 +62,7 @@ func TestNewDefaultTransportChain(t *testing.T) {
 		dt := NewDefaultTransportChain().Final(tr)
 
 		req := httptest.NewRequest("GET", "/foo", nil)
+		req = req.WithContext(log.WithContext(context.Background()))
 		resp, err := dt.RoundTrip(req)
 		if err != nil {
 			t.Fatalf("Expected err to be nil, got %#v", err)


### PR DESCRIPTION
before due to the ordering the only the first and last response
ended up in the logs. Additionally, the drained request body
could have caused issues with the retry mechanim.