### PR TITLE
Make errors.Hide no longer prepend the external error message

### DIFF
--- a/maintenance/errors/context.go
+++ b/maintenance/errors/context.go
@@ -21,12 +21,12 @@ func Hide(ctx context.Context, err, exposedErr error) error {
 	}
 
 	if ctx.Err() == context.Canceled && errors.Is(err, context.Canceled) {
-		s := strings.TrimSuffix(ret.Error(), context.Canceled.Error())
+		s := strings.TrimSuffix(err.Error(), context.Canceled.Error())
 		return fmt.Errorf("%s%w", s, context.Canceled)
 	}
 
 	if ctx.Err() == context.DeadlineExceeded && errors.Is(err, context.DeadlineExceeded) {
-		s := strings.TrimSuffix(ret.Error(), context.DeadlineExceeded.Error())
+		s := strings.TrimSuffix(err.Error(), context.DeadlineExceeded.Error())
 		return fmt.Errorf("%s%w", s, context.DeadlineExceeded)
 	}
 

--- a/maintenance/errors/context_test.go
+++ b/maintenance/errors/context_test.go
@@ -102,7 +102,7 @@ func TestHide(t *testing.T) {
 				err:        fmt.Errorf("%s: %w", iAmAnError, context.Canceled),
 				exposedErr: iAmAnotherError,
 			},
-			want: fmt.Errorf("%s: %s: %w", iAmAnotherError, iAmAnError, context.Canceled),
+			want: fmt.Errorf("%s: %w", iAmAnError, context.Canceled),
 		},
 		{
 			name: "exceeded_context_no_error_nothing_exposed",
@@ -138,7 +138,7 @@ func TestHide(t *testing.T) {
 				err:        fmt.Errorf("%s: %w", iAmAnError, context.DeadlineExceeded),
 				exposedErr: iAmAnotherError,
 			},
-			want: fmt.Errorf("%s: %s: %w", iAmAnotherError, iAmAnError, context.DeadlineExceeded),
+			want: fmt.Errorf("%s: %w", iAmAnError, context.DeadlineExceeded),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This was deemed too confusing as the prepended error message is expected to define the
error type, but in this case it keeps being a context error