### PR TITLE
grpc: delete utm metadata entry

### DIFF
--- a/grpc/server.go
+++ b/grpc/server.go
@@ -192,6 +192,7 @@ func prepareContext(ctx context.Context) (context.Context, metadata.MD) {
 	delete(md, "locale")
 	delete(md, "bearer_token")
 	delete(md, "req_id")
+	delete(md, utmMetadataKey) // why is this even needed?
 
 	return ctx, md
 }


### PR DESCRIPTION
Follow convention, but I am not sure why we do this for other entries.
The grpc documentation does not indicate any need to do that: https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md