### PR TITLE
Add postgres option to control query logging

### DIFF
--- a/backend/postgres/options.go
+++ b/backend/postgres/options.go
@@ -168,3 +168,10 @@ func WithHealthCheckResultTTL(healthCheckResultTTL time.Duration) ConfigOption {
 		cfg.HealthCheckResultTTL = healthCheckResultTTL
 	}
 }
+
+// WithQueryLogging - Controls if SQL queries are logged
+func WithQueryLogging(logging bool) ConfigOption {
+	return func(cfg *Config) {
+		cfg.QueryLogging = logging
+	}
+}

--- a/backend/postgres/options_test.go
+++ b/backend/postgres/options_test.go
@@ -173,3 +173,11 @@ func TestWithWriteTimeout(t *testing.T) {
 	f(&conf)
 	require.Equal(t, conf.WriteTimeout, param)
 }
+
+func TestWithQueryLogging(t *testing.T) {
+	param := true
+	var conf Config
+	f := WithQueryLogging(param)
+	f(&conf)
+	require.Equal(t, conf.QueryLogging, param)
+}


### PR DESCRIPTION
Added another postgres configuration option to control SQL logging behaviour. Can be used via ENV or controlled via variadic parameters.