### PR TITLE
Avoid appending to redis health check key

### DIFF
--- a/backend/redis/health_redis.go
+++ b/backend/redis/health_redis.go
@@ -30,7 +30,7 @@ func (h *HealthCheck) HealthCheck(ctx context.Context) servicehealthcheck.Health
 	}
 
 	// Try writing
-	if err := client.Append(cfg.HealthCheckKey, "true").Err(); err != nil {
+	if err := client.Set(cfg.HealthCheckKey, "true", 0).Err(); err != nil {
 		h.state.SetErrorState(err)
 		return h.state.GetState()
 	}


### PR DESCRIPTION
Preventing the value of the key getting VERY large:

![SCR-20220406-kqv](https://user-images.githubusercontent.com/1431474/161979550-6686bd3c-ac89-4986-ac6a-de5d899e5cfe.png)

