### PR TITLE
Sanitise operationID handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/dave/jennifer v1.0.2
+	github.com/ettle/strcase v0.1.1
 	github.com/getkin/kin-openapi v0.0.0-20180813063848-e1956e8013e5
 	github.com/go-kivik/couchdb/v3 v3.2.6
 	github.com/go-kivik/kivik/v3 v3.2.3

--- a/http/jsonapi/generator/generate_handler.go
+++ b/http/jsonapi/generator/generate_handler.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/dave/jennifer/jen"
+	"github.com/ettle/strcase"
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/pace/bricks/maintenance/log"
@@ -548,6 +549,8 @@ func (g *Generator) buildHandler(method string, op *openapi3.Operation, pattern 
 		log.Warnf("Note: Avoid automatic method name generation for path (use OperationID): %s", pattern)
 		oid = generateName(method, op, pattern)
 	}
+	// sanitise operationID
+	oid = strcase.ToGoCamel(oid)
 	handler := oid + "Handler"
 	route.handler = handler
 	route.serviceFunc = oid

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,6 +59,7 @@ github.com/denis-tingajkin/go-header
 # github.com/esimonov/ifshort v1.0.2
 github.com/esimonov/ifshort/pkg/analyzer
 # github.com/ettle/strcase v0.1.1
+## explicit
 github.com/ettle/strcase
 # github.com/fatih/color v1.12.0
 github.com/fatih/color


### PR DESCRIPTION
According to the Open API Specification (https://swagger.io/specification/) an operation id may contain characters which are not allowed as part of a function name (e.g. dashes). using them will prevent the generation of a valid api specification. To prevent this failure, a additional sanitation is proposed which converts the given operationID into camelCase notation.