### PR TITLE
fix: return actual error, not creating a new one

### DIFF
--- a/maintenance/errors/context.go
+++ b/maintenance/errors/context.go
@@ -19,7 +19,7 @@ func Hide(ctx context.Context, err, exposedErr error) error {
 		return nil
 	}
 
-	ret := errors.New(err.Error())
+	ret := err
 	if exposedErr != nil {
 		ret = fmt.Errorf("%w: %s", exposedErr, err)
 	}

--- a/maintenance/errors/context_test.go
+++ b/maintenance/errors/context_test.go
@@ -58,7 +58,7 @@ func TestHide(t *testing.T) {
 				err:        fmt.Errorf("%s: %w", iAmAnError, context.Canceled),
 				exposedErr: nil,
 			},
-			want:             fmt.Errorf("%s: %s", iAmAnError, context.Canceled),
+			want:             fmt.Errorf("%s: %w", iAmAnError, context.Canceled),
 			expectContextErr: true,
 		},
 		{


### PR DESCRIPTION
Fix to return the actual error, not creating a new one which created a mapping error