### PR TITLE
fix pg pagination

### DIFF
--- a/http/jsonapi/runtime/standard_params.go
+++ b/http/jsonapi/runtime/standard_params.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caarlos0/env"
 	"github.com/go-pg/pg"
 	"github.com/go-pg/pg/orm"
+
 	"github.com/pace/bricks/maintenance/log"
 )
 
@@ -102,12 +103,7 @@ func ReadURLQueryParameters(r *http.Request, mapper ColumnMapper, sanitizer Valu
 // AddToQuery adds filter, sorting and pagination to a orm.Query
 func (u *UrlQueryParameters) AddToQuery(query *orm.Query) *orm.Query {
 	if u.HasPagination {
-		if u.PageNr == 0 {
-			query.Offset(0)
-		} else {
-			query.Offset((u.PageSize * u.PageNr) - 1)
-		}
-		query.Limit(u.PageSize)
+		query.Offset(u.PageSize * u.PageNr).Limit(u.PageSize)
 	}
 	for name, filterValues := range u.Filter {
 		if len(filterValues) == 0 {


### PR DESCRIPTION
Old behavior used to include the last item from the previously returned page because of `-1` on the offset. The existing tests did not cover this issue, new test cases were added to cover this.