### PR TITLE
.github: Update docker/login-action to v3

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: Login to DockerHub
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
docker/login-action@v1 seems to be using the deprecated `save-state` command, it therefore should be updated to v3.