### PR TITLE
middleware: Use map for external dependencies

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -8,10 +8,11 @@ jobs:
       matrix:
         go: [ '1.23' ]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
+        check-latest: true
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:

--- a/grpc/server_test.go
+++ b/grpc/server_test.go
@@ -79,7 +79,8 @@ func TestPrepareContext(t *testing.T) {
 
 	externalDependencyContext := middleware.ExternalDependencyContextFromContext(ctx3)
 	require.NotNil(t, externalDependencyContext)
-	assert.Equal(t, "foo:60000,bar:1000", externalDependencyContext.String())
+	// Output is sorted by name
+	assert.Equal(t, "bar:1000,foo:60000", externalDependencyContext.String())
 
 	ctx = metadata.NewIncomingContext(context.Background(), metadata.MD{})
 

--- a/http/middleware/external_dependency_test.go
+++ b/http/middleware/external_dependency_test.go
@@ -56,6 +56,10 @@ func Test_ExternalDependencyContext_String(t *testing.T) {
 
 	edc.AddDependency("test4", time.Millisecond*123)
 	assert.EqualValues(t, "test1:1,test2:0,test3:1000,test4:123", edc.String())
+
+	// This should update the previous value
+	edc.AddDependency("test4", time.Millisecond*123)
+	assert.EqualValues(t, "test1:1,test2:0,test3:1000,test4:246", edc.String())
 }
 
 func Test_ExternalDependencyContext_Parse(t *testing.T) {
@@ -78,4 +82,8 @@ func Test_ExternalDependencyContext_Parse(t *testing.T) {
 
 	edc.Parse("test3:1000,test4:123")
 	assert.EqualValues(t, "test1:1,test2:0,test3:1000,test4:123", edc.String())
+
+	// This should update the previous value
+	edc.Parse("test3:1000")
+	assert.EqualValues(t, "test1:1,test2:0,test3:2000,test4:123", edc.String())
 }


### PR DESCRIPTION
This replaces the dependency slice with a map. The duration of external dependencies is now accumulated instead of appended to the slice.