### PR TITLE
make enabling sentry tracing configurable; default is true

### DIFF
--- a/maintenance/tracing/README.md
+++ b/maintenance/tracing/README.md
@@ -8,4 +8,5 @@ Property| Description
 --- | ---
 `SENTRY_DSN`  | The DSN to use.
 `ENVIRONMENT` | The environment to be sent with events.
-`SENTRY_TRACES_SAMPLE_RATE` | The tracing sample rate to use (default 0.1).
+`SENTRY_TRACES_SAMPLE_RATE` | The tracing sample rate to use (default: 0.1).
+`SENTRY_ENABLE_TRACING` | Enable or disable tracing (default: true).

--- a/maintenance/tracing/tracing.go
+++ b/maintenance/tracing/tracing.go
@@ -15,7 +15,10 @@ import (
 )
 
 func init() {
-	var tracesSampleRate float64 = 0.1
+	var (
+		tracesSampleRate = 0.1
+		enableTracing    = true
+	)
 
 	val := strings.TrimSpace(os.Getenv("SENTRY_TRACES_SAMPLE_RATE"))
 	if val != "" {
@@ -27,10 +30,20 @@ func init() {
 		}
 	}
 
+	valEnableTracing := strings.TrimSpace(os.Getenv("SENTRY_ENABLE_TRACING"))
+	if valEnableTracing != "" {
+		var err error
+
+		enableTracing, err = strconv.ParseBool(valEnableTracing)
+		if err != nil {
+			log.Fatalf("failed to parse SENTRY_ENABLE_TRACING: %v", err)
+		}
+	}
+
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              os.Getenv("SENTRY_DSN"),
 		Environment:      os.Getenv("ENVIRONMENT"),
-		EnableTracing:    true,
+		EnableTracing:    enableTracing,
 		TracesSampleRate: tracesSampleRate,
 		BeforeSendTransaction: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			// Drop request body.


### PR DESCRIPTION
This adds a new environment variable that makes it possible to disable sentry tracing for a specific service. Tracing is enabled per default.