### PR TITLE
http/longpoll: Fix bug and simplify implementation

### DIFF
--- a/http/longpoll/longpoll_test.go
+++ b/http/longpoll/longpoll_test.go
@@ -37,7 +37,13 @@ func TestLongPollUntilBounds(t *testing.T) {
 
 func TestLongPollUntilNoTimeout(t *testing.T) {
 	called := 0
-	ok, err := Until(context.Background(), 0, func(context.Context) (bool, error) {
+	ok, err := Until(context.Background(), 0, func(ctx context.Context) (bool, error) {
+		f := func(ctx context.Context) {
+			assert.NoError(t, ctx.Err())
+		}
+
+		f(ctx)
+
 		called++
 		return false, nil
 	})
@@ -73,8 +79,8 @@ func TestLongPollUntilTimeout(t *testing.T) {
 		return false, nil
 	})
 	assert.False(t, ok)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, called)
+	assert.Error(t, err)
+	assert.GreaterOrEqual(t, called, 2)
 }
 
 func TestLongPollUntilTimeoutWithContext(t *testing.T) {


### PR DESCRIPTION
This fixes a bug where if duration was set to 0 the context would expire instantly causing any context-aware function to stop.