### PR TITLE
oauth2: Lower log level for Oauth2 message

### DIFF
--- a/http/oauth2/oauth2.go
+++ b/http/oauth2/oauth2.go
@@ -94,7 +94,7 @@ func introspectRequest(r *http.Request, w http.ResponseWriter, tokenIntro TokenI
 	t := fromIntrospectResponse(s, tok)
 	ctx = security.ContextWithToken(ctx, &t)
 
-	log.Req(r).Info().
+	log.Req(r).Debug().
 		Str("client_id", t.clientID).
 		Str("user_id", t.userID).
 		Msg("Oauth2")


### PR DESCRIPTION
This message pollutes the logs. Its level can be safely lowered to Debug.